### PR TITLE
added ignore for IJ output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 
 # Ignore InteliJ resources
 .idea
+
+# Ignore InteliJ output directory
+out


### PR DESCRIPTION
Viva professor, reparei que quando foi alterado o sistema que executa os testes do gradle para o IJ o mesmo tem uma diretoria nova `out` com os .class gerados na compilação.